### PR TITLE
Fix authorization for non-ownerable models

### DIFF
--- a/src/Policy.php
+++ b/src/Policy.php
@@ -61,17 +61,17 @@ abstract class Policy
             return Response::allow();
         }
 
-        return $this->userHasAccessToModel($user, $model) !== false ? Response::allow() : $this->denyResponse($ability);
+        return $this->userHasAccessToModel($user, $model) ? Response::allow() : $this->denyResponse($ability);
     }
 
     protected function userHasAccessToModel(IUser $user, object $model): ?bool
     {
         if (!$model instanceof IOwnerableModel) {
-            return null;
+            return true;
         }
         $ownerId = $model->getOwnerUserId();
         if (null === $ownerId) {
-            return null;
+            return false;
         }
         if ($user->getId() == $ownerId) {
             return true;

--- a/src/Policy.php
+++ b/src/Policy.php
@@ -61,7 +61,7 @@ abstract class Policy
             return Response::allow();
         }
 
-        return $this->userHasAccessToModel($user, $model) ? Response::allow() : $this->denyResponse($ability);
+        return $this->userHasAccessToModel($user, $model) !== false ? Response::allow() : $this->denyResponse($ability);
     }
 
     protected function userHasAccessToModel(IUser $user, object $model): ?bool

--- a/tests/Doubles/NoOwnerableModel.php
+++ b/tests/Doubles/NoOwnerableModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace dnj\AAA\Tests\Doubles;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NoOwnerableModel extends Model
+{
+    protected $guarded = [];
+    protected $table = 'aaa_noownerable';
+}

--- a/tests/Doubles/NoOwnerablePolicy.php
+++ b/tests/Doubles/NoOwnerablePolicy.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace dnj\AAA\Tests\Doubles;
+
+use dnj\AAA\Policy;
+
+class NoOwnerablePolicy extends Policy
+{
+    public function getModel(): string
+    {
+        return NoOwnerableModel::class;
+    }
+}

--- a/tests/Doubles/migrations/2023_02_26_000001_create_noownerable_table.php
+++ b/tests/Doubles/migrations/2023_02_26_000001_create_noownerable_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::create('aaa_noownerable', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('aaa_noownerable');
+    }
+};

--- a/tests/Feature/PolicyTest.php
+++ b/tests/Feature/PolicyTest.php
@@ -8,6 +8,8 @@ use dnj\AAA\Models\User;
 use dnj\AAA\Policy;
 use dnj\AAA\Tests\Doubles\DummyModel;
 use dnj\AAA\Tests\Doubles\DummyPolicy;
+use dnj\AAA\Tests\Doubles\NoOwnerableModel;
+use dnj\AAA\Tests\Doubles\NoOwnerablePolicy;
 use dnj\AAA\Tests\TestCase;
 
 class PolicyTest extends TestCase
@@ -54,5 +56,22 @@ class PolicyTest extends TestCase
 
         $dummy = DummyModel::query()->create(['owner_id' => $subUser->id]);
         $this->assertTrue($policy->update($user, $dummy)->allowed());
+    }
+
+    public function testNoOwnerableModel(): void
+    {
+        $this->loadMigrationsFrom(dirname(__DIR__) . '/Doubles/migrations');
+
+        $userType = Type::factory()
+            ->has(TypeAbility::factory()->withName(Policy::getModelAbilityName(NoOwnerableModel::class, 'view')), 'abilities')
+            ->create();
+
+        $user = User::factory()
+            ->withType($userType)
+            ->create();
+
+        $policy = app()->make(NoOwnerablePolicy::class);
+        $dummy = NoOwnerableModel::query()->create([]);
+        $this->assertTrue($policy->view($user, $dummy)->allowed());
     }
 }


### PR DESCRIPTION
# Problem
When a model does not implemented `IOwnerableModel` interface, `Policy::userHasAccessToModel()` always returns null but in `Policy::accessProcessor()` this considered as `false`.

# Solution
I check explicitly for return of `Policy::userHasAccessToModel()` to be not false